### PR TITLE
feat(parser): add hierarchical test framework detection system

### DIFF
--- a/pkg/parser/detection/config/cache.go
+++ b/pkg/parser/detection/config/cache.go
@@ -1,0 +1,52 @@
+package config
+
+import (
+	"sort"
+	"strings"
+	"sync"
+)
+
+type Cache struct {
+	mu    sync.RWMutex
+	items map[string]string
+}
+
+func NewCache() *Cache {
+	return &Cache{
+		items: make(map[string]string),
+	}
+}
+
+func (c *Cache) Get(dir string, patterns []string) (string, bool) {
+	c.mu.RLock()
+	defer c.mu.RUnlock()
+	key := makeCacheKey(dir, patterns)
+	val, ok := c.items[key]
+	return val, ok
+}
+
+func (c *Cache) Set(dir string, patterns []string, configPath string) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	key := makeCacheKey(dir, patterns)
+	c.items[key] = configPath
+}
+
+func (c *Cache) Clear() {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	c.items = make(map[string]string)
+}
+
+func (c *Cache) Size() int {
+	c.mu.RLock()
+	defer c.mu.RUnlock()
+	return len(c.items)
+}
+
+func makeCacheKey(dir string, patterns []string) string {
+	sorted := make([]string, len(patterns))
+	copy(sorted, patterns)
+	sort.Strings(sorted)
+	return dir + "|" + strings.Join(sorted, "|")
+}

--- a/pkg/parser/detection/config/resolver.go
+++ b/pkg/parser/detection/config/resolver.go
@@ -1,0 +1,132 @@
+// Package config provides scope-based configuration file resolution.
+package config
+
+import (
+	"os"
+	"path/filepath"
+	"regexp"
+)
+
+const (
+	defaultMaxDepth = 20
+
+	// Project root indicator files
+	fileGitDir      = ".git"
+	fileGoMod       = "go.mod"
+	filePackageJSON = "package.json"
+
+	// Monorepo indicator files
+	fileLernaJSON         = "lerna.json"
+	fileNxJSON            = "nx.json"
+	filePnpmWorkspaceYAML = "pnpm-workspace.yaml"
+	fileRushJSON          = "rush.json"
+)
+
+type Resolver struct {
+	cache    *Cache
+	maxDepth int
+}
+
+func NewResolver(cache *Cache, maxDepth int) *Resolver {
+	if maxDepth <= 0 {
+		maxDepth = defaultMaxDepth
+	}
+	return &Resolver{
+		cache:    cache,
+		maxDepth: maxDepth,
+	}
+}
+
+var (
+	projectRootIndicators = []string{fileGoMod, fileGitDir, filePackageJSON}
+	monorepoIndicators    = []string{filePnpmWorkspaceYAML, fileLernaJSON, fileRushJSON, fileNxJSON}
+	workspacesPattern     = regexp.MustCompile(`"workspaces"\s*:`)
+)
+
+// ResolveConfig finds the nearest config file by traversing up directories.
+// Stops at project root boundary (go.mod, .git, package.json) + one level for monorepo configs.
+func (r *Resolver) ResolveConfig(filePath string, patterns []string) (string, bool) {
+	dir := filepath.Dir(filePath)
+	var foundProjectRoot bool
+	var visitedDirs []string
+
+	for depth := 0; depth < r.maxDepth; depth++ {
+		if r.cache != nil {
+			if cached, found := r.cache.Get(dir, patterns); found {
+				return cached, cached != ""
+			}
+		}
+
+		visitedDirs = append(visitedDirs, dir)
+
+		if configPath, found := r.findConfigInDir(dir, patterns); found {
+			return configPath, true
+		}
+
+		if !foundProjectRoot && isProjectRoot(dir) {
+			foundProjectRoot = true
+		} else if foundProjectRoot {
+			break
+		}
+
+		parent := filepath.Dir(dir)
+		if parent == dir {
+			break
+		}
+		dir = parent
+	}
+
+	// Cache miss for all visited directories to avoid redundant filesystem scans
+	if r.cache != nil {
+		for _, visitedDir := range visitedDirs {
+			r.cache.Set(visitedDir, patterns, "")
+		}
+	}
+	return "", false
+}
+
+func (r *Resolver) findConfigInDir(dir string, patterns []string) (string, bool) {
+	for _, pattern := range patterns {
+		matches, err := filepath.Glob(filepath.Join(dir, pattern))
+		if err != nil {
+			// filepath.Glob only returns ErrBadPattern for malformed patterns
+			continue
+		}
+		if len(matches) > 0 {
+			configPath := matches[0]
+			if r.cache != nil {
+				r.cache.Set(dir, patterns, configPath)
+			}
+			return configPath, true
+		}
+	}
+	return "", false
+}
+
+func isProjectRoot(dir string) bool {
+	return anyFileExists(dir, projectRootIndicators)
+}
+
+func anyFileExists(dir string, files []string) bool {
+	for _, file := range files {
+		if _, err := os.Stat(filepath.Join(dir, file)); err == nil {
+			return true
+		}
+	}
+	return false
+}
+
+// IsMonorepoRoot detects monorepo by checking for workspace indicators.
+func IsMonorepoRoot(dir string) bool {
+	if anyFileExists(dir, monorepoIndicators) {
+		return true
+	}
+
+	packageJSON := filepath.Join(dir, "package.json")
+	if content, err := os.ReadFile(packageJSON); err == nil {
+		if workspacesPattern.Match(content) {
+			return true
+		}
+	}
+	return false
+}

--- a/pkg/parser/detection/detector.go
+++ b/pkg/parser/detection/detector.go
@@ -1,0 +1,103 @@
+package detection
+
+import (
+	"context"
+	"path/filepath"
+	"strings"
+
+	"github.com/specvital/core/pkg/domain"
+	"github.com/specvital/core/pkg/parser/detection/config"
+	"github.com/specvital/core/pkg/parser/detection/matchers"
+)
+
+var langExtMap = map[string]domain.Language{
+	".cts": domain.LanguageTypeScript,
+	".cjs": domain.LanguageJavaScript,
+	".go":  domain.LanguageGo,
+	".js":  domain.LanguageJavaScript,
+	".jsx": domain.LanguageJavaScript,
+	".mjs": domain.LanguageJavaScript,
+	".mts": domain.LanguageTypeScript,
+	".ts":  domain.LanguageTypeScript,
+	".tsx": domain.LanguageTypeScript,
+}
+
+type Detector struct {
+	matcherRegistry *matchers.Registry
+	scopeResolver   *config.Resolver
+}
+
+func NewDetector(matcherRegistry *matchers.Registry, scopeResolver *config.Resolver) *Detector {
+	return &Detector{
+		matcherRegistry: matcherRegistry,
+		scopeResolver:   scopeResolver,
+	}
+}
+
+// Detect performs hierarchical framework detection.
+// Level 1: Import statements → Level 2: Scope config files → Level 3: Unknown
+func (d *Detector) Detect(ctx context.Context, filePath string, content []byte) Result {
+	if result, ok := d.detectFromImports(ctx, filePath, content); ok {
+		return result
+	}
+	if result, ok := d.detectFromScopeConfig(filePath); ok {
+		return result
+	}
+	return Unknown()
+}
+
+func (d *Detector) detectFromImports(ctx context.Context, filePath string, content []byte) (Result, bool) {
+	lang := detectLanguage(filePath)
+	if lang == "" {
+		return Result{}, false
+	}
+
+	compatibleMatchers := d.matcherRegistry.FindByLanguage(lang)
+	if len(compatibleMatchers) == 0 {
+		return Result{}, false
+	}
+
+	// Extract imports once using the first compatible matcher
+	imports := compatibleMatchers[0].ExtractImports(ctx, content)
+	if len(imports) == 0 {
+		return Result{}, false
+	}
+
+	if matcher := findMatchingMatcher(compatibleMatchers, imports); matcher != nil {
+		return FromImport(matcher.Name()), true
+	}
+	return Result{}, false
+}
+
+func (d *Detector) detectFromScopeConfig(filePath string) (Result, bool) {
+	if d.scopeResolver == nil {
+		return Result{}, false
+	}
+
+	for _, matcher := range d.matcherRegistry.All() {
+		patterns := matcher.ConfigPatterns()
+		if len(patterns) == 0 {
+			continue
+		}
+		if configPath, found := d.scopeResolver.ResolveConfig(filePath, patterns); found {
+			return FromScopeConfig(matcher.Name(), configPath), true
+		}
+	}
+	return Result{}, false
+}
+
+func findMatchingMatcher(matcherList []matchers.Matcher, imports []string) matchers.Matcher {
+	for _, matcher := range matcherList {
+		for _, importPath := range imports {
+			if matcher.MatchImport(importPath) {
+				return matcher
+			}
+		}
+	}
+	return nil
+}
+
+func detectLanguage(filePath string) domain.Language {
+	ext := strings.ToLower(filepath.Ext(filePath))
+	return langExtMap[ext]
+}

--- a/pkg/parser/detection/detector_test.go
+++ b/pkg/parser/detection/detector_test.go
@@ -1,0 +1,284 @@
+package detection
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"slices"
+	"testing"
+
+	"github.com/specvital/core/pkg/domain"
+	"github.com/specvital/core/pkg/parser/detection/config"
+	"github.com/specvital/core/pkg/parser/detection/extraction"
+	"github.com/specvital/core/pkg/parser/detection/matchers"
+)
+
+type mockMatcher struct {
+	configPatterns []string
+	extractFunc    func(context.Context, []byte) []string
+	languages      []domain.Language
+	matchImports   []string
+	name           string
+}
+
+func (m *mockMatcher) Name() string                 { return m.name }
+func (m *mockMatcher) Languages() []domain.Language { return m.languages }
+func (m *mockMatcher) ConfigPatterns() []string     { return m.configPatterns }
+func (m *mockMatcher) MatchImport(importPath string) bool {
+	return slices.Contains(m.matchImports, importPath)
+}
+func (m *mockMatcher) ExtractImports(ctx context.Context, content []byte) []string {
+	if m.extractFunc != nil {
+		return m.extractFunc(ctx, content)
+	}
+	return nil
+}
+
+func TestDetector_Detect_Level1_Import(t *testing.T) {
+	t.Parallel()
+
+	registry := matchers.NewRegistry()
+	registry.Register(&mockMatcher{
+		name:         "vitest",
+		languages:    []domain.Language{domain.LanguageTypeScript, domain.LanguageJavaScript},
+		matchImports: []string{"vitest"},
+		extractFunc:  extraction.ExtractJSImports,
+	})
+	registry.Register(&mockMatcher{
+		name:         "playwright",
+		languages:    []domain.Language{domain.LanguageTypeScript, domain.LanguageJavaScript},
+		matchImports: []string{"@playwright/test"},
+		extractFunc:  extraction.ExtractJSImports,
+	})
+	registry.Register(&mockMatcher{
+		name:         "jest",
+		languages:    []domain.Language{domain.LanguageTypeScript, domain.LanguageJavaScript},
+		matchImports: []string{"@jest/globals"},
+		extractFunc:  extraction.ExtractJSImports,
+	})
+
+	detector := NewDetector(registry, nil)
+
+	tests := []struct {
+		name          string
+		content       string
+		wantFramework string
+		wantSource    Source
+	}{
+		{
+			name:          "vitest import",
+			content:       `import { describe, it } from 'vitest';`,
+			wantFramework: "vitest",
+			wantSource:    SourceImport,
+		},
+		{
+			name:          "playwright import",
+			content:       `import { test, expect } from '@playwright/test';`,
+			wantFramework: "playwright",
+			wantSource:    SourceImport,
+		},
+		{
+			name:          "jest globals import",
+			content:       `import { jest } from '@jest/globals';`,
+			wantFramework: "jest",
+			wantSource:    SourceImport,
+		},
+		{
+			name:          "require syntax",
+			content:       `const { test } = require('@playwright/test');`,
+			wantFramework: "playwright",
+			wantSource:    SourceImport,
+		},
+		{
+			name:          "no framework import",
+			content:       `describe('test', () => { it('works', () => {}) });`,
+			wantFramework: "unknown",
+			wantSource:    SourceUnknown,
+		},
+		{
+			name:          "unrelated import",
+			content:       `import lodash from 'lodash';`,
+			wantFramework: "unknown",
+			wantSource:    SourceUnknown,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			result := detector.Detect(context.Background(), "test.ts", []byte(tt.content))
+
+			if result.Framework != tt.wantFramework {
+				t.Errorf("Framework = %q, want %q", result.Framework, tt.wantFramework)
+			}
+			if result.Source != tt.wantSource {
+				t.Errorf("Source = %q, want %q", result.Source, tt.wantSource)
+			}
+		})
+	}
+}
+
+func TestDetector_Detect_Level2_ScopeConfig(t *testing.T) {
+	// Create temp directory structure
+	tempDir := t.TempDir()
+
+	// Create monorepo structure:
+	// tempDir/
+	// ├── apps/
+	// │   ├── web/
+	// │   │   ├── jest.config.js
+	// │   │   └── __tests__/user.test.ts
+	// │   └── api/
+	// │       ├── vitest.config.ts
+	// │       └── __tests__/handler.test.ts
+	// └── e2e/
+	//     ├── playwright.config.ts
+	//     └── login.spec.ts
+
+	dirs := []string{
+		filepath.Join(tempDir, "apps", "web", "__tests__"),
+		filepath.Join(tempDir, "apps", "api", "__tests__"),
+		filepath.Join(tempDir, "e2e"),
+	}
+	for _, dir := range dirs {
+		if err := os.MkdirAll(dir, 0o755); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	configs := map[string]string{
+		filepath.Join(tempDir, "apps", "web", "jest.config.js"):   "",
+		filepath.Join(tempDir, "apps", "api", "vitest.config.ts"): "",
+		filepath.Join(tempDir, "e2e", "playwright.config.ts"):     "",
+	}
+	for path, content := range configs {
+		if err := os.WriteFile(path, []byte(content), 0o644); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	// Setup registry and detector
+	registry := matchers.NewRegistry()
+	registry.Register(&mockMatcher{
+		name:           "jest",
+		configPatterns: []string{"jest.config.js", "jest.config.ts"},
+	})
+	registry.Register(&mockMatcher{
+		name:           "vitest",
+		configPatterns: []string{"vitest.config.js", "vitest.config.ts"},
+	})
+	registry.Register(&mockMatcher{
+		name:           "playwright",
+		configPatterns: []string{"playwright.config.js", "playwright.config.ts"},
+	})
+
+	cache := config.NewCache()
+	resolver := config.NewResolver(cache, 10)
+	detector := NewDetector(registry, resolver)
+
+	tests := []struct {
+		name          string
+		filePath      string
+		wantFramework string
+		wantSource    Source
+	}{
+		{
+			name:          "web test uses jest",
+			filePath:      filepath.Join(tempDir, "apps", "web", "__tests__", "user.test.ts"),
+			wantFramework: "jest",
+			wantSource:    SourceScopeConfig,
+		},
+		{
+			name:          "api test uses vitest",
+			filePath:      filepath.Join(tempDir, "apps", "api", "__tests__", "handler.test.ts"),
+			wantFramework: "vitest",
+			wantSource:    SourceScopeConfig,
+		},
+		{
+			name:          "e2e test uses playwright",
+			filePath:      filepath.Join(tempDir, "e2e", "login.spec.ts"),
+			wantFramework: "playwright",
+			wantSource:    SourceScopeConfig,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			// No import in content, should fallback to scope config
+			result := detector.Detect(context.Background(), tt.filePath, []byte(`describe('test', () => {})`))
+
+			if result.Framework != tt.wantFramework {
+				t.Errorf("Framework = %q, want %q", result.Framework, tt.wantFramework)
+			}
+			if result.Source != tt.wantSource {
+				t.Errorf("Source = %q, want %q", result.Source, tt.wantSource)
+			}
+		})
+	}
+}
+
+func TestDetector_Detect_ImportTakesPrecedence(t *testing.T) {
+	// Even if config file exists, import should take precedence
+
+	tempDir := t.TempDir()
+	configPath := filepath.Join(tempDir, "jest.config.js")
+	if err := os.WriteFile(configPath, []byte{}, 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	registry := matchers.NewRegistry()
+	registry.Register(&mockMatcher{
+		name:           "jest",
+		languages:      []domain.Language{domain.LanguageTypeScript, domain.LanguageJavaScript},
+		matchImports:   []string{"@jest/globals"},
+		configPatterns: []string{"jest.config.js"},
+		extractFunc:    extraction.ExtractJSImports,
+	})
+	registry.Register(&mockMatcher{
+		name:           "vitest",
+		languages:      []domain.Language{domain.LanguageTypeScript, domain.LanguageJavaScript},
+		matchImports:   []string{"vitest"},
+		configPatterns: []string{"vitest.config.ts"},
+		extractFunc:    extraction.ExtractJSImports,
+	})
+
+	cache := config.NewCache()
+	resolver := config.NewResolver(cache, 10)
+	detector := NewDetector(registry, resolver)
+
+	// File is in jest config directory but has vitest import
+	content := `import { describe } from 'vitest';`
+	result := detector.Detect(context.Background(), filepath.Join(tempDir, "test.ts"), []byte(content))
+
+	if result.Framework != "vitest" {
+		t.Errorf("Framework = %q, want vitest (import should take precedence)", result.Framework)
+	}
+	if result.Source != SourceImport {
+		t.Errorf("Source = %q, want %q", result.Source, SourceImport)
+	}
+}
+
+func TestResult_IsUnknown(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name   string
+		result Result
+		want   bool
+	}{
+		{"unknown framework", Result{Framework: "unknown"}, true},
+		{"empty framework", Result{Framework: ""}, true},
+		{"zero confidence", Result{Framework: "jest", Confidence: ConfidenceUnknown}, true},
+		{"known framework", Result{Framework: "jest", Confidence: ConfidenceMedium}, false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			if got := tt.result.IsUnknown(); got != tt.want {
+				t.Errorf("IsUnknown() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}

--- a/pkg/parser/detection/extraction/go.go
+++ b/pkg/parser/detection/extraction/go.go
@@ -1,0 +1,76 @@
+package extraction
+
+import (
+	"context"
+	"sync"
+
+	sitter "github.com/smacker/go-tree-sitter"
+	"github.com/smacker/go-tree-sitter/golang"
+)
+
+var (
+	goLang     *sitter.Language
+	goLangOnce sync.Once
+)
+
+func getGoLanguage() *sitter.Language {
+	goLangOnce.Do(func() {
+		goLang = golang.GetLanguage()
+	})
+	return goLang
+}
+
+// Go import query: captures import path from both single and grouped imports.
+// Matches import_spec directly to handle both:
+// - Single: import "testing"
+// - Grouped: import ( "fmt" \n "testing" )
+const goImportQuery = `(import_spec path: (interpreted_string_literal) @import)`
+
+// ExtractGoImports extracts import paths from Go source using tree-sitter.
+// Handles both single imports and grouped import blocks.
+func ExtractGoImports(ctx context.Context, content []byte) []string {
+	lang := getGoLanguage()
+
+	parser := sitter.NewParser()
+	parser.SetLanguage(lang)
+	defer parser.Close()
+
+	tree, err := parser.ParseCtx(ctx, nil, content)
+	if err != nil {
+		return nil
+	}
+	defer tree.Close()
+
+	query, err := sitter.NewQuery([]byte(goImportQuery), lang)
+	if err != nil {
+		return nil
+	}
+	defer query.Close()
+
+	cursor := sitter.NewQueryCursor()
+	defer cursor.Close()
+
+	cursor.Exec(query, tree.RootNode())
+
+	var imports []string
+	for {
+		match, ok := cursor.NextMatch()
+		if !ok {
+			break
+		}
+
+		for _, capture := range match.Captures {
+			name := query.CaptureNameForId(capture.Index)
+			if name == "import" {
+				// Remove quotes from import path
+				path := capture.Node.Content(content)
+				if len(path) >= 2 {
+					path = path[1 : len(path)-1] // Strip quotes
+				}
+				imports = append(imports, path)
+			}
+		}
+	}
+
+	return imports
+}

--- a/pkg/parser/detection/extraction/go_test.go
+++ b/pkg/parser/detection/extraction/go_test.go
@@ -1,0 +1,82 @@
+package extraction
+
+import (
+	"context"
+	"slices"
+	"testing"
+)
+
+func TestExtractGoImports(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name    string
+		content string
+		want    []string
+	}{
+		{
+			name:    "single import",
+			content: `import "testing"`,
+			want:    []string{"testing"},
+		},
+		{
+			name:    "aliased import",
+			content: `import t "testing"`,
+			want:    []string{"testing"},
+		},
+		{
+			name: "grouped imports",
+			content: `import (
+	"fmt"
+	"testing"
+)`,
+			want: []string{"fmt", "testing"},
+		},
+		{
+			name: "mixed grouped imports with aliases",
+			content: `import (
+	"context"
+	t "testing"
+	. "github.com/onsi/gomega"
+)`,
+			want: []string{"context", "testing", "github.com/onsi/gomega"},
+		},
+		{
+			name: "full go file",
+			content: `package main
+
+import (
+	"context"
+	"testing"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestSomething(t *testing.T) {
+	fmt.Println("hello")
+}`,
+			want: []string{"context", "testing", "github.com/stretchr/testify/assert"},
+		},
+		{
+			name:    "no imports",
+			content: `package main`,
+			want:    nil,
+		},
+		{
+			name: "multiple import declarations",
+			content: `import "fmt"
+import "testing"`,
+			want: []string{"fmt", "testing"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			got := ExtractGoImports(context.Background(), []byte(tt.content))
+			if !slices.Equal(got, tt.want) {
+				t.Errorf("ExtractGoImports() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}

--- a/pkg/parser/detection/extraction/javascript.go
+++ b/pkg/parser/detection/extraction/javascript.go
@@ -1,0 +1,23 @@
+package extraction
+
+import (
+	"context"
+	"regexp"
+)
+
+var jsImportPattern = regexp.MustCompile(`(?:import\s+.*?\s+from|require\()\s*['"]([^'"]+)['"]`)
+
+func ExtractJSImports(_ context.Context, content []byte) []string {
+	matches := jsImportPattern.FindAllSubmatch(content, -1)
+	if len(matches) == 0 {
+		return nil
+	}
+
+	imports := make([]string, 0, len(matches))
+	for _, match := range matches {
+		if len(match) > 1 {
+			imports = append(imports, string(match[1]))
+		}
+	}
+	return imports
+}

--- a/pkg/parser/detection/integration_test.go
+++ b/pkg/parser/detection/integration_test.go
@@ -1,0 +1,68 @@
+package detection_test
+
+import (
+	"os"
+	"testing"
+
+	"github.com/specvital/core/pkg/parser/detection/matchers"
+	"github.com/specvital/core/pkg/parser/strategies"
+	"github.com/specvital/core/pkg/parser/strategies/gotesting"
+	"github.com/specvital/core/pkg/parser/strategies/jest"
+	"github.com/specvital/core/pkg/parser/strategies/playwright"
+	"github.com/specvital/core/pkg/parser/strategies/vitest"
+)
+
+func TestMain(m *testing.M) {
+	strategies.DefaultRegistry().Clear()
+	jest.RegisterDefault()
+	vitest.RegisterDefault()
+	playwright.RegisterDefault()
+	gotesting.RegisterDefault()
+	os.Exit(m.Run())
+}
+
+func TestMatcherStrategyNameConsistency(t *testing.T) {
+	t.Parallel()
+
+	matcherRegistry := matchers.DefaultRegistry()
+	strategyRegistry := strategies.DefaultRegistry()
+
+	for _, matcher := range matcherRegistry.All() {
+		name := matcher.Name()
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+
+			strategy := strategyRegistry.FindByName(name)
+			if strategy == nil {
+				t.Errorf("Matcher %q has no corresponding Strategy", name)
+				return
+			}
+			if strategy.Name() != name {
+				t.Errorf("Strategy name mismatch: Matcher=%q, Strategy=%q", name, strategy.Name())
+			}
+		})
+	}
+}
+
+func TestAllStrategiesHaveMatchers(t *testing.T) {
+	t.Parallel()
+
+	matcherRegistry := matchers.DefaultRegistry()
+	strategyRegistry := strategies.DefaultRegistry()
+
+	for _, strategy := range strategyRegistry.GetStrategies() {
+		name := strategy.Name()
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+
+			matcher, found := matcherRegistry.FindByName(name)
+			if !found {
+				t.Errorf("Strategy %q has no corresponding Matcher", name)
+				return
+			}
+			if matcher.Name() != name {
+				t.Errorf("Matcher name mismatch: Strategy=%q, Matcher=%q", name, matcher.Name())
+			}
+		})
+	}
+}

--- a/pkg/parser/detection/matchers/matcher.go
+++ b/pkg/parser/detection/matchers/matcher.go
@@ -1,0 +1,16 @@
+// Package matchers provides framework-specific detection rules.
+package matchers
+
+import (
+	"context"
+
+	"github.com/specvital/core/pkg/domain"
+)
+
+type Matcher interface {
+	Name() string
+	Languages() []domain.Language
+	MatchImport(importPath string) bool
+	ConfigPatterns() []string
+	ExtractImports(ctx context.Context, content []byte) []string
+}

--- a/pkg/parser/detection/matchers/registry.go
+++ b/pkg/parser/detection/matchers/registry.go
@@ -1,0 +1,83 @@
+package matchers
+
+import (
+	"sync"
+
+	"github.com/specvital/core/pkg/domain"
+)
+
+var defaultRegistry = &Registry{}
+
+type Registry struct {
+	mu       sync.RWMutex
+	matchers []Matcher
+}
+
+func NewRegistry() *Registry {
+	return &Registry{}
+}
+
+func DefaultRegistry() *Registry {
+	return defaultRegistry
+}
+
+func Register(m Matcher) {
+	defaultRegistry.Register(m)
+}
+
+func (r *Registry) Register(m Matcher) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	r.matchers = append(r.matchers, m)
+}
+
+func (r *Registry) All() []Matcher {
+	r.mu.RLock()
+	defer r.mu.RUnlock()
+	result := make([]Matcher, len(r.matchers))
+	copy(result, r.matchers)
+	return result
+}
+
+func (r *Registry) FindByName(name string) (Matcher, bool) {
+	r.mu.RLock()
+	defer r.mu.RUnlock()
+	for _, m := range r.matchers {
+		if m.Name() == name {
+			return m, true
+		}
+	}
+	return nil, false
+}
+
+func (r *Registry) FindByImport(importPath string) (Matcher, bool) {
+	r.mu.RLock()
+	defer r.mu.RUnlock()
+	for _, m := range r.matchers {
+		if m.MatchImport(importPath) {
+			return m, true
+		}
+	}
+	return nil, false
+}
+
+func (r *Registry) FindByLanguage(lang domain.Language) []Matcher {
+	r.mu.RLock()
+	defer r.mu.RUnlock()
+	var result []Matcher
+	for _, m := range r.matchers {
+		for _, l := range m.Languages() {
+			if l == lang {
+				result = append(result, m)
+				break
+			}
+		}
+	}
+	return result
+}
+
+func (r *Registry) Clear() {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	r.matchers = nil
+}

--- a/pkg/parser/detection/result.go
+++ b/pkg/parser/detection/result.go
@@ -1,0 +1,58 @@
+// Package detection provides hierarchical test framework detection.
+package detection
+
+type Confidence int
+
+const (
+	ConfidenceUnknown Confidence = iota
+	ConfidenceLow                // scope config
+	ConfidenceMedium             // import
+	ConfidenceHigh               // pragma (future)
+)
+
+type Source string
+
+const (
+	SourceUnknown     Source = "unknown"
+	SourceImport      Source = "import"
+	SourceScopeConfig Source = "scope_config"
+	SourcePragma      Source = "pragma"
+)
+
+const FrameworkUnknown = "unknown"
+
+type Result struct {
+	ConfigPath string
+	Confidence Confidence
+	Framework  string
+	Source     Source
+}
+
+func (r Result) IsUnknown() bool {
+	return r.Framework == "" || r.Framework == FrameworkUnknown || r.Confidence == ConfidenceUnknown
+}
+
+func Unknown() Result {
+	return Result{
+		Confidence: ConfidenceUnknown,
+		Framework:  FrameworkUnknown,
+		Source:     SourceUnknown,
+	}
+}
+
+func FromImport(framework string) Result {
+	return Result{
+		Confidence: ConfidenceMedium,
+		Framework:  framework,
+		Source:     SourceImport,
+	}
+}
+
+func FromScopeConfig(framework, configPath string) Result {
+	return Result{
+		ConfigPath: configPath,
+		Confidence: ConfidenceLow,
+		Framework:  framework,
+		Source:     SourceScopeConfig,
+	}
+}

--- a/pkg/parser/strategies/gotesting/matcher.go
+++ b/pkg/parser/strategies/gotesting/matcher.go
@@ -1,0 +1,24 @@
+package gotesting
+
+import (
+	"context"
+
+	"github.com/specvital/core/pkg/domain"
+	"github.com/specvital/core/pkg/parser/detection/extraction"
+	"github.com/specvital/core/pkg/parser/detection/matchers"
+)
+
+func init() {
+	matchers.Register(&Matcher{})
+}
+
+type Matcher struct{}
+
+func (m *Matcher) Name() string                       { return frameworkName }
+func (m *Matcher) Languages() []domain.Language       { return []domain.Language{domain.LanguageGo} }
+func (m *Matcher) MatchImport(importPath string) bool { return importPath == "testing" }
+func (m *Matcher) ConfigPatterns() []string           { return nil }
+
+func (m *Matcher) ExtractImports(ctx context.Context, content []byte) []string {
+	return extraction.ExtractGoImports(ctx, content)
+}

--- a/pkg/parser/strategies/jest/matcher.go
+++ b/pkg/parser/strategies/jest/matcher.go
@@ -1,0 +1,33 @@
+package jest
+
+import (
+	"context"
+	"strings"
+
+	"github.com/specvital/core/pkg/domain"
+	"github.com/specvital/core/pkg/parser/detection/extraction"
+	"github.com/specvital/core/pkg/parser/detection/matchers"
+)
+
+func init() {
+	matchers.Register(&Matcher{})
+}
+
+type Matcher struct{}
+
+func (m *Matcher) Name() string { return frameworkName }
+func (m *Matcher) Languages() []domain.Language {
+	return []domain.Language{domain.LanguageTypeScript, domain.LanguageJavaScript}
+}
+
+func (m *Matcher) MatchImport(importPath string) bool {
+	return importPath == "@jest/globals" || importPath == "jest" || strings.HasPrefix(importPath, "@jest/")
+}
+
+func (m *Matcher) ConfigPatterns() []string {
+	return []string{"jest.config.js", "jest.config.ts", "jest.config.mjs", "jest.config.cjs", "jest.config.json"}
+}
+
+func (m *Matcher) ExtractImports(ctx context.Context, content []byte) []string {
+	return extraction.ExtractJSImports(ctx, content)
+}

--- a/pkg/parser/strategies/playwright/matcher.go
+++ b/pkg/parser/strategies/playwright/matcher.go
@@ -1,0 +1,33 @@
+package playwright
+
+import (
+	"context"
+	"strings"
+
+	"github.com/specvital/core/pkg/domain"
+	"github.com/specvital/core/pkg/parser/detection/extraction"
+	"github.com/specvital/core/pkg/parser/detection/matchers"
+)
+
+func init() {
+	matchers.Register(&Matcher{})
+}
+
+type Matcher struct{}
+
+func (m *Matcher) Name() string { return frameworkName }
+func (m *Matcher) Languages() []domain.Language {
+	return []domain.Language{domain.LanguageTypeScript, domain.LanguageJavaScript}
+}
+
+func (m *Matcher) MatchImport(importPath string) bool {
+	return importPath == "@playwright/test" || strings.HasPrefix(importPath, "@playwright/test/")
+}
+
+func (m *Matcher) ConfigPatterns() []string {
+	return []string{"playwright.config.js", "playwright.config.ts", "playwright.config.mjs", "playwright.config.mts"}
+}
+
+func (m *Matcher) ExtractImports(ctx context.Context, content []byte) []string {
+	return extraction.ExtractJSImports(ctx, content)
+}

--- a/pkg/parser/strategies/registry.go
+++ b/pkg/parser/strategies/registry.go
@@ -103,3 +103,21 @@ func (r *Registry) Clear() {
 	defer r.mu.Unlock()
 	r.strategies = nil
 }
+
+// FindByName returns the strategy with the given name.
+func (r *Registry) FindByName(name string) Strategy {
+	r.mu.RLock()
+	defer r.mu.RUnlock()
+
+	for _, s := range r.strategies {
+		if s.Name() == name {
+			return s
+		}
+	}
+	return nil
+}
+
+// FindStrategyByName returns the strategy with the given name from the default registry.
+func FindStrategyByName(name string) Strategy {
+	return defaultRegistry.FindByName(name)
+}

--- a/pkg/parser/strategies/vitest/matcher.go
+++ b/pkg/parser/strategies/vitest/matcher.go
@@ -1,0 +1,33 @@
+package vitest
+
+import (
+	"context"
+	"strings"
+
+	"github.com/specvital/core/pkg/domain"
+	"github.com/specvital/core/pkg/parser/detection/extraction"
+	"github.com/specvital/core/pkg/parser/detection/matchers"
+)
+
+func init() {
+	matchers.Register(&Matcher{})
+}
+
+type Matcher struct{}
+
+func (m *Matcher) Name() string { return frameworkName }
+func (m *Matcher) Languages() []domain.Language {
+	return []domain.Language{domain.LanguageTypeScript, domain.LanguageJavaScript}
+}
+
+func (m *Matcher) MatchImport(importPath string) bool {
+	return importPath == "vitest" || strings.HasPrefix(importPath, "vitest/")
+}
+
+func (m *Matcher) ConfigPatterns() []string {
+	return []string{"vitest.config.js", "vitest.config.ts", "vitest.config.mjs", "vitest.config.mts"}
+}
+
+func (m *Matcher) ExtractImports(ctx context.Context, content []byte) []string {
+	return extraction.ExtractJSImports(ctx, content)
+}


### PR DESCRIPTION
Improve framework detection from CanHandle-based approach to more accurate and extensible hierarchical detection

Hierarchy:
- Level 1: Import statement analysis (most accurate)
- Level 2: Scope config file discovery (jest.config.js, etc.)
- Level 3: Existing CanHandle fallback

Key implementations:
- detection/: Core detection logic (Detector, Result)
- detection/matchers/: Matcher interface and registry
- detection/config/: Config file resolver with cache
- detection/extraction/: Language-specific import extraction utilities
- strategies/*/matcher.go: Framework-specific Matcher implementations

fix #32