### PR TITLE
fix(detection): add ProjectContext for source-agnostic framework detection

### DIFF
--- a/pkg/parser/detection/context.go
+++ b/pkg/parser/detection/context.go
@@ -1,0 +1,117 @@
+package detection
+
+import (
+	"path/filepath"
+	"slices"
+	"sort"
+	"strings"
+
+	"github.com/specvital/core/pkg/parser/detection/matchers"
+)
+
+// ProjectContext provides project-level metadata for framework detection.
+// Enables source-agnostic detection for both local filesystem and remote sources (e.g., GitHub API).
+//
+// Thread-safety:
+//   - Construction: Use [ProjectContextBuilder] for safe construction. Builder methods are NOT
+//     thread-safe; complete all builder operations in a single goroutine before calling Build().
+//   - After construction: ProjectContext is immutable. Concurrent reads are safe.
+//   - Do NOT call AddConfigFile or SetConfigContent after passing to Scan().
+type ProjectContext struct {
+	ConfigFiles    []string
+	ConfigContents map[string]*matchers.ConfigInfo
+}
+
+func NewProjectContext() *ProjectContext {
+	return &ProjectContext{
+		ConfigFiles:    []string{},
+		ConfigContents: make(map[string]*matchers.ConfigInfo),
+	}
+}
+
+// AddConfigFile adds a config file path. NOT thread-safe; use only during construction.
+func (pc *ProjectContext) AddConfigFile(path string) {
+	pc.ConfigFiles = append(pc.ConfigFiles, path)
+}
+
+// SetConfigContent sets parsed config info for a path. NOT thread-safe; use only during construction.
+// Requires pc to be initialized via NewProjectContext() or NewProjectContextBuilder().
+func (pc *ProjectContext) SetConfigContent(path string, info *matchers.ConfigInfo) {
+	pc.ConfigContents[path] = info
+}
+
+// FindApplicableConfig returns the nearest config for a source file path.
+// Traverses up directory tree; root-level configs act as fallbacks.
+// Returns nil if no config found.
+func (pc *ProjectContext) FindApplicableConfig(filePath string) *matchers.ConfigInfo {
+	_, info := pc.findNearestConfig(filePath, nil)
+	return info
+}
+
+// FindConfigPath returns the nearest config path for a source file with optional framework filter.
+func (pc *ProjectContext) FindConfigPath(filePath, framework string) string {
+	var filter func(*matchers.ConfigInfo) bool
+	if framework != "" {
+		filter = func(info *matchers.ConfigInfo) bool {
+			return info.Framework == framework
+		}
+	}
+	path, _ := pc.findNearestConfig(filePath, filter)
+	return path
+}
+
+func (pc *ProjectContext) findNearestConfig(filePath string, filter func(*matchers.ConfigInfo) bool) (string, *matchers.ConfigInfo) {
+	if pc == nil || len(pc.ConfigContents) == 0 {
+		return "", nil
+	}
+
+	filePath = filepath.ToSlash(filePath)
+	fileDir := filepath.Dir(filePath)
+
+	type candidate struct {
+		depth int
+		info  *matchers.ConfigInfo
+		path  string
+	}
+
+	var candidates []candidate
+	for path, info := range pc.ConfigContents {
+		if info == nil {
+			continue
+		}
+		if filter != nil && !filter(info) {
+			continue
+		}
+
+		normalizedPath := filepath.ToSlash(path)
+		configDir := filepath.Dir(normalizedPath)
+		if configDir == "." {
+			configDir = ""
+		}
+
+		if configDir == "" || strings.HasPrefix(fileDir, configDir) {
+			depth := strings.Count(configDir, "/")
+			candidates = append(candidates, candidate{path: path, info: info, depth: depth})
+		}
+	}
+
+	if len(candidates) == 0 {
+		return "", nil
+	}
+
+	sort.Slice(candidates, func(i, j int) bool {
+		return candidates[i].depth > candidates[j].depth
+	})
+
+	return candidates[0].path, candidates[0].info
+}
+
+func (pc *ProjectContext) HasConfigFile(pattern string) bool {
+	if pc == nil {
+		return false
+	}
+
+	return slices.ContainsFunc(pc.ConfigFiles, func(path string) bool {
+		return filepath.Base(path) == pattern
+	})
+}

--- a/pkg/parser/detection/context_builder.go
+++ b/pkg/parser/detection/context_builder.go
@@ -1,0 +1,75 @@
+package detection
+
+import (
+	"path/filepath"
+	"slices"
+
+	"github.com/specvital/core/pkg/parser/detection/matchers"
+)
+
+// ProjectContextBuilder constructs ProjectContext from file lists and config contents.
+type ProjectContextBuilder struct {
+	ctx      *ProjectContext
+	registry *matchers.Registry
+}
+
+func NewProjectContextBuilder(registry *matchers.Registry) *ProjectContextBuilder {
+	return &ProjectContextBuilder{
+		ctx:      NewProjectContext(),
+		registry: registry,
+	}
+}
+
+// AddConfigFiles filters and registers config file paths from a file list.
+func (b *ProjectContextBuilder) AddConfigFiles(filePaths []string) *ProjectContextBuilder {
+	configPatterns := b.collectConfigPatterns()
+
+	for _, path := range filePaths {
+		baseName := filepath.Base(path)
+		if configPatterns[baseName] {
+			b.ctx.AddConfigFile(path)
+		}
+	}
+
+	return b
+}
+
+// ParseConfigContent parses config content using the appropriate matcher.
+// Matchers are sorted by priority (highest first) to ensure consistent behavior
+// when multiple matchers could handle the same config pattern.
+func (b *ProjectContextBuilder) ParseConfigContent(configPath string, content []byte) *ProjectContextBuilder {
+	baseName := filepath.Base(configPath)
+
+	matcherList := sortedByPriority(b.registry.All())
+
+	for _, matcher := range matcherList {
+		patterns := matcher.ConfigPatterns()
+		if len(patterns) == 0 {
+			continue
+		}
+		if slices.Contains(patterns, baseName) {
+			if info := matcher.ParseConfig(content); info != nil {
+				b.ctx.SetConfigContent(configPath, info)
+			}
+			return b
+		}
+	}
+
+	return b
+}
+
+func (b *ProjectContextBuilder) Build() *ProjectContext {
+	return b.ctx
+}
+
+func (b *ProjectContextBuilder) collectConfigPatterns() map[string]bool {
+	patterns := make(map[string]bool)
+
+	for _, matcher := range b.registry.All() {
+		for _, pattern := range matcher.ConfigPatterns() {
+			patterns[pattern] = true
+		}
+	}
+
+	return patterns
+}

--- a/pkg/parser/detection/extraction/javascript.go
+++ b/pkg/parser/detection/extraction/javascript.go
@@ -21,3 +21,13 @@ func ExtractJSImports(_ context.Context, content []byte) []string {
 	}
 	return imports
 }
+
+var commentStripRegex = regexp.MustCompile(`//.*|/\*[\s\S]*?\*/`)
+
+// MatchPatternExcludingComments checks if pattern matches content after stripping comments.
+// Handles both single-line (//) and multi-line (/* */) comments.
+// Limitation: Does not handle comments inside string literals.
+func MatchPatternExcludingComments(content []byte, pattern *regexp.Regexp) bool {
+	noComments := commentStripRegex.ReplaceAll(content, []byte{})
+	return pattern.Match(noComments)
+}

--- a/pkg/parser/detection/matchers/matcher.go
+++ b/pkg/parser/detection/matchers/matcher.go
@@ -7,10 +7,26 @@ import (
 	"github.com/specvital/core/pkg/domain"
 )
 
+// Priority determines detection order when multiple frameworks could match.
+// Higher values = checked first. Use increments of 50 for future insertions.
+const (
+	PriorityGeneric     = 100 // jest, go-testing
+	PriorityE2E         = 150 // playwright
+	PrioritySpecialized = 200 // vitest (has specific globals mode)
+)
+
+type ConfigInfo struct {
+	Framework   string
+	GlobalsMode bool
+}
+
+// Matcher defines the interface for framework-specific detection.
 type Matcher interface {
 	Name() string
 	Languages() []domain.Language
 	MatchImport(importPath string) bool
 	ConfigPatterns() []string
 	ExtractImports(ctx context.Context, content []byte) []string
+	ParseConfig(content []byte) *ConfigInfo
+	Priority() int
 }

--- a/pkg/parser/detection/result.go
+++ b/pkg/parser/detection/result.go
@@ -5,18 +5,19 @@ type Confidence int
 
 const (
 	ConfidenceUnknown Confidence = iota
-	ConfidenceLow                // scope config
-	ConfidenceMedium             // import
-	ConfidenceHigh               // pragma (future)
+	ConfidenceLow                // scope config (config file exists in directory tree)
+	ConfidenceMedium             // import (explicit import statement)
+	ConfidenceHigh               // project context (config parsed with globals mode)
 )
 
 type Source string
 
 const (
-	SourceUnknown     Source = "unknown"
-	SourceImport      Source = "import"
-	SourceScopeConfig Source = "scope_config"
-	SourcePragma      Source = "pragma"
+	SourceUnknown        Source = "unknown"
+	SourceImport         Source = "import"
+	SourceScopeConfig    Source = "scope_config"
+	SourceProjectContext Source = "project_context"
+	SourcePragma         Source = "pragma"
 )
 
 const FrameworkUnknown = "unknown"
@@ -54,5 +55,14 @@ func FromScopeConfig(framework, configPath string) Result {
 		Confidence: ConfidenceLow,
 		Framework:  framework,
 		Source:     SourceScopeConfig,
+	}
+}
+
+func FromProjectContext(framework, configPath string) Result {
+	return Result{
+		ConfigPath: configPath,
+		Confidence: ConfidenceHigh,
+		Framework:  framework,
+		Source:     SourceProjectContext,
 	}
 }

--- a/pkg/parser/options.go
+++ b/pkg/parser/options.go
@@ -1,6 +1,10 @@
 package parser
 
-import "time"
+import (
+	"time"
+
+	"github.com/specvital/core/pkg/parser/detection"
+)
 
 // ScanOptions configures the behavior of [Scan].
 type ScanOptions struct {
@@ -10,6 +14,9 @@ type ScanOptions struct {
 	MaxFileSize int64
 	// Patterns specifies glob patterns to match test files (e.g., "**/*.test.ts").
 	Patterns []string
+	// ProjectContext provides project-level metadata for source-agnostic detection.
+	// When set, enables detection without filesystem access (e.g., GitHub API environment).
+	ProjectContext *detection.ProjectContext
 	// Timeout is the maximum duration for the entire scan operation.
 	Timeout time.Duration
 	// Workers is the number of concurrent file parsers.
@@ -66,5 +73,15 @@ func WithWorkers(n int) ScanOption {
 			return
 		}
 		o.Workers = n
+	}
+}
+
+// WithProjectContext returns a [ScanOption] that sets the project context.
+// This enables source-agnostic detection for environments without filesystem access
+// (e.g., GitHub API). The ProjectContext should contain config file paths and
+// their parsed contents.
+func WithProjectContext(ctx *detection.ProjectContext) ScanOption {
+	return func(o *ScanOptions) {
+		o.ProjectContext = ctx
 	}
 }

--- a/pkg/parser/strategies/gotesting/matcher.go
+++ b/pkg/parser/strategies/gotesting/matcher.go
@@ -8,6 +8,8 @@ import (
 	"github.com/specvital/core/pkg/parser/detection/matchers"
 )
 
+const matcherPriority = matchers.PriorityGeneric
+
 func init() {
 	matchers.Register(&Matcher{})
 }
@@ -21,4 +23,13 @@ func (m *Matcher) ConfigPatterns() []string           { return nil }
 
 func (m *Matcher) ExtractImports(ctx context.Context, content []byte) []string {
 	return extraction.ExtractGoImports(ctx, content)
+}
+
+func (m *Matcher) ParseConfig(_ []byte) *matchers.ConfigInfo {
+	// Go testing always requires explicit import, no config file
+	return nil
+}
+
+func (m *Matcher) Priority() int {
+	return matcherPriority
 }

--- a/pkg/parser/strategies/jest/matcher_test.go
+++ b/pkg/parser/strategies/jest/matcher_test.go
@@ -1,0 +1,98 @@
+package jest
+
+import "testing"
+
+func TestMatcher_ParseConfig(t *testing.T) {
+	t.Parallel()
+
+	m := &Matcher{}
+
+	tests := []struct {
+		name            string
+		content         string
+		wantGlobalsMode bool
+	}{
+		{
+			name: "default config (globals enabled by default)",
+			content: `module.exports = {
+				testEnvironment: 'node',
+			}`,
+			wantGlobalsMode: true,
+		},
+		{
+			name: "injectGlobals explicitly true",
+			content: `module.exports = {
+				injectGlobals: true,
+			}`,
+			wantGlobalsMode: true,
+		},
+		{
+			name: "injectGlobals false",
+			content: `module.exports = {
+				injectGlobals: false,
+			}`,
+			wantGlobalsMode: false,
+		},
+		{
+			name: "injectGlobals false with spaces",
+			content: `module.exports = {
+				injectGlobals :  false,
+			}`,
+			wantGlobalsMode: false,
+		},
+		{
+			name:            "empty config",
+			content:         `module.exports = {}`,
+			wantGlobalsMode: true, // Jest defaults to globals enabled
+		},
+		{
+			name: "JSON config",
+			content: `{
+				"testEnvironment": "node"
+			}`,
+			wantGlobalsMode: true,
+		},
+		{
+			name: "commented injectGlobals false should be ignored",
+			content: `module.exports = {
+				// injectGlobals: false,
+				testEnvironment: 'node',
+			}`,
+			wantGlobalsMode: true,
+		},
+		{
+			name: "injectGlobals false after comment",
+			content: `module.exports = {
+				// some comment
+				injectGlobals: false,
+			}`,
+			wantGlobalsMode: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			info := m.ParseConfig([]byte(tt.content))
+			if info == nil {
+				t.Fatal("ParseConfig returned nil")
+			}
+			if info.Framework != frameworkName {
+				t.Errorf("Framework = %q, want %q", info.Framework, frameworkName)
+			}
+			if info.GlobalsMode != tt.wantGlobalsMode {
+				t.Errorf("GlobalsMode = %v, want %v", info.GlobalsMode, tt.wantGlobalsMode)
+			}
+		})
+	}
+}
+
+func TestMatcher_Priority(t *testing.T) {
+	t.Parallel()
+
+	m := &Matcher{}
+	if m.Priority() != matcherPriority {
+		t.Errorf("Priority() = %d, want %d", m.Priority(), matcherPriority)
+	}
+}

--- a/pkg/parser/strategies/playwright/matcher.go
+++ b/pkg/parser/strategies/playwright/matcher.go
@@ -9,6 +9,8 @@ import (
 	"github.com/specvital/core/pkg/parser/detection/matchers"
 )
 
+const matcherPriority = matchers.PriorityE2E
+
 func init() {
 	matchers.Register(&Matcher{})
 }
@@ -16,6 +18,7 @@ func init() {
 type Matcher struct{}
 
 func (m *Matcher) Name() string { return frameworkName }
+
 func (m *Matcher) Languages() []domain.Language {
 	return []domain.Language{domain.LanguageTypeScript, domain.LanguageJavaScript}
 }
@@ -30,4 +33,16 @@ func (m *Matcher) ConfigPatterns() []string {
 
 func (m *Matcher) ExtractImports(ctx context.Context, content []byte) []string {
 	return extraction.ExtractJSImports(ctx, content)
+}
+
+func (m *Matcher) ParseConfig(content []byte) *matchers.ConfigInfo {
+	// Playwright always requires explicit imports, no globals mode
+	return &matchers.ConfigInfo{
+		Framework:   frameworkName,
+		GlobalsMode: false,
+	}
+}
+
+func (m *Matcher) Priority() int {
+	return matcherPriority
 }

--- a/pkg/parser/strategies/vitest/matcher.go
+++ b/pkg/parser/strategies/vitest/matcher.go
@@ -2,12 +2,17 @@ package vitest
 
 import (
 	"context"
+	"regexp"
 	"strings"
 
 	"github.com/specvital/core/pkg/domain"
 	"github.com/specvital/core/pkg/parser/detection/extraction"
 	"github.com/specvital/core/pkg/parser/detection/matchers"
 )
+
+const matcherPriority = matchers.PrioritySpecialized
+
+var globalsPattern = regexp.MustCompile(`globals\s*:\s*true`)
 
 func init() {
 	matchers.Register(&Matcher{})
@@ -16,6 +21,7 @@ func init() {
 type Matcher struct{}
 
 func (m *Matcher) Name() string { return frameworkName }
+
 func (m *Matcher) Languages() []domain.Language {
 	return []domain.Language{domain.LanguageTypeScript, domain.LanguageJavaScript}
 }
@@ -30,4 +36,15 @@ func (m *Matcher) ConfigPatterns() []string {
 
 func (m *Matcher) ExtractImports(ctx context.Context, content []byte) []string {
 	return extraction.ExtractJSImports(ctx, content)
+}
+
+func (m *Matcher) ParseConfig(content []byte) *matchers.ConfigInfo {
+	return &matchers.ConfigInfo{
+		Framework:   frameworkName,
+		GlobalsMode: extraction.MatchPatternExcludingComments(content, globalsPattern),
+	}
+}
+
+func (m *Matcher) Priority() int {
+	return matcherPriority
 }

--- a/pkg/parser/strategies/vitest/matcher_test.go
+++ b/pkg/parser/strategies/vitest/matcher_test.go
@@ -1,0 +1,103 @@
+package vitest
+
+import "testing"
+
+func TestMatcher_ParseConfig(t *testing.T) {
+	t.Parallel()
+
+	m := &Matcher{}
+
+	tests := []struct {
+		name            string
+		content         string
+		wantGlobalsMode bool
+	}{
+		{
+			name: "globals true",
+			content: `export default defineConfig({
+				test: {
+					globals: true,
+				}
+			})`,
+			wantGlobalsMode: true,
+		},
+		{
+			name: "globals true with spaces",
+			content: `export default {
+				test: {
+					globals :  true,
+				}
+			}`,
+			wantGlobalsMode: true,
+		},
+		{
+			name: "globals false",
+			content: `export default defineConfig({
+				test: {
+					globals: false,
+				}
+			})`,
+			wantGlobalsMode: false,
+		},
+		{
+			name: "no globals setting",
+			content: `export default defineConfig({
+				test: {
+					environment: 'jsdom',
+				}
+			})`,
+			wantGlobalsMode: false,
+		},
+		{
+			name:            "empty config",
+			content:         `export default {}`,
+			wantGlobalsMode: false,
+		},
+		{
+			name: "commented globals true should be ignored",
+			content: `export default defineConfig({
+				test: {
+					// globals: true,
+					environment: 'jsdom',
+				}
+			})`,
+			wantGlobalsMode: false,
+		},
+		{
+			name: "globals true after comment",
+			content: `export default defineConfig({
+				test: {
+					// some comment
+					globals: true,
+				}
+			})`,
+			wantGlobalsMode: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			info := m.ParseConfig([]byte(tt.content))
+			if info == nil {
+				t.Fatal("ParseConfig returned nil")
+			}
+			if info.Framework != frameworkName {
+				t.Errorf("Framework = %q, want %q", info.Framework, frameworkName)
+			}
+			if info.GlobalsMode != tt.wantGlobalsMode {
+				t.Errorf("GlobalsMode = %v, want %v", info.GlobalsMode, tt.wantGlobalsMode)
+			}
+		})
+	}
+}
+
+func TestMatcher_Priority(t *testing.T) {
+	t.Parallel()
+
+	m := &Matcher{}
+	if m.Priority() != matcherPriority {
+		t.Errorf("Priority() = %d, want %d", m.Priority(), matcherPriority)
+	}
+}


### PR DESCRIPTION
Resolve vitest globals mode detection failure in GitHub API environments

Problem:
- vitest globals: true allows describe/it without imports
- GitHub API environment cannot access filesystem for config lookup
- Falls back to Jest causing incorrect framework detection

Solution:
- Introduce ProjectContext for external file list and config injection
- Add DetectWithContext() method (backward compatible with Detect())
- Extend Matcher interface with ParseConfig() and Priority()
- Parse globals mode to accurately detect test files without imports
- Apply correct config scope per monorepo subproject

fix #34